### PR TITLE
Add note on mlx-lm model bringup process

### DIFF
--- a/content/notes/llm-inference-from-scratch.md
+++ b/content/notes/llm-inference-from-scratch.md
@@ -193,17 +193,21 @@ Apple Silicon uses **unified memory** — CPU and GPU share the same RAM. The ke
 | M1 | 68 GB/s |
 | M1 Pro/Max | 200-400 GB/s |
 | M2 Ultra | 800 GB/s |
+| **M3 Ultra** | **819 GB/s** |
 | M4 Pro | 273 GB/s |
+| M5 Pro | 307 GB/s |
 
 During decode (one token at a time), the GPU must load ALL model weights from memory for each token. A 4-bit 7B model = ~3.5 GB of weights loaded per token.
 
-At 200 GB/s bandwidth: 3.5 GB / 200 GB/s = 0.0175s per token → ~57 tokens/sec theoretical max.
+On an M3 Ultra (819 GB/s): 3.5 GB / 819 GB/s = 0.0043s per token → ~234 tokens/sec theoretical max.
+On an M5 Pro (307 GB/s): 3.5 GB / 307 GB/s = 0.0114s per token → ~88 tokens/sec theoretical max.
 
 This is why:
 - Smaller models are faster (less to load)
 - Quantization helps (smaller weights = less to load)
 - Prefill is faster per-token than decode (batched tokens amortize the weight loading)
-- Our benchmark showed Qwen 0.8B at ~245 tok/s vs 9B at ~80 tok/s — roughly proportional to model size
+- Higher bandwidth chips are proportionally faster at decode
+- Our benchmark on M3 Ultra showed Qwen 0.8B at ~245 tok/s vs 9B at ~80 tok/s — roughly proportional to model size
 
 ## 10. Putting It All Together: What mlx-lm Does
 

--- a/content/notes/llm-inference-from-scratch.md
+++ b/content/notes/llm-inference-from-scratch.md
@@ -1,0 +1,250 @@
+---
+title: "LLM Inference From Scratch: Basics to MLX Serving"
+date: 2026-04-07T00:00:00+0800
+tags: [llm, inference, mlx, apple-silicon, fundamentals]
+---
+
+Building up from basic concepts to understanding what happens when you run a model with mlx-lm on Apple Silicon. Each section builds on the previous one.
+
+## 1. Tensors: The Data Structure
+
+Everything in an LLM is a **tensor** — a multi-dimensional array of numbers. Think of it as:
+
+- 1D tensor = a list: `[1.0, 2.0, 3.0]`
+- 2D tensor = a table/matrix: rows × columns
+- 3D tensor = a stack of tables: batch × rows × columns
+
+Model weights are tensors. Inputs are tensors. Outputs are tensors. The entire computation is tensor math.
+
+## 2. The Forward Pass: Input → Output
+
+Running a model = executing a sequence of math operations on tensors. This is called the **forward pass**.
+
+For an LLM, the simplified forward pass is:
+
+```
+"Hello world" → tokenize → [15496, 995] → embed → tensor(2, 768) → 
+  [transformer layers × N] → tensor(2, 768) → project to vocab → 
+  tensor(2, 50257) → pick highest → next token ID → "!"
+```
+
+Step by step:
+
+1. **Tokenize** — convert text to token IDs (integers). "Hello" might be token 15496.
+2. **Embed** — look up each token ID in a big table to get a vector of numbers (e.g., 768 floats). Now you have a tensor of shape (num_tokens, hidden_size).
+3. **Transformer layers** — run the tensor through N layers (24, 32, 80... depends on model size). Each layer modifies the tensor. This is where the "intelligence" lives.
+4. **Project** — multiply by vocabulary matrix to get a score for every possible next token.
+5. **Pick** — take the highest-scored token. That's the model's prediction.
+
+## 3. What a Transformer Layer Does
+
+Each layer has two main parts: **Attention** and **MLP** (feed-forward network).
+
+### Attention: "What should I focus on?"
+
+Given a sequence of tokens, attention lets each token look at all previous tokens and decide how much to "pay attention" to each one.
+
+Concretely:
+1. Each token gets transformed into three vectors: **Query (Q)**, **Key (K)**, **Value (V)**
+2. Q and K are multiplied together to get attention scores (which tokens are relevant to which)
+3. Scores are used to create a weighted mix of V vectors
+4. Result: each token now contains information from the tokens it attended to
+
+The math: `Attention(Q, K, V) = softmax(Q × K^T / √d) × V`
+
+This is all matrix multiplications — the single most performance-critical operation.
+
+### MLP: "Process what I focused on"
+
+After attention, each token's vector goes through a feed-forward network:
+
+```
+input → Linear(expand) → activation → Linear(shrink) → output
+```
+
+This expands the vector (e.g., 768 → 3072), applies a non-linearity, then shrinks it back. It's where the model stores and applies "knowledge."
+
+### Residual Connections
+
+After each sub-step (attention, MLP), the original input is added back:
+
+```
+output = input + attention(input)
+output = output + mlp(output)
+```
+
+This "residual connection" is critical — without it, deep models can't train. It means information can skip layers if needed.
+
+## 4. Prefill vs Decode: Two Phases of Generation
+
+When you ask a model to generate text, there are two distinct phases:
+
+### Prefill (process the prompt)
+
+All prompt tokens are processed **at once** in parallel. The model runs the full forward pass on the entire prompt in one shot.
+
+- Input: all N prompt tokens simultaneously
+- Compute: N tokens × N tokens attention (everyone looks at everyone before them)
+- Output: the hidden state + a prediction for the first generated token
+- This is **compute-bound** — lots of math on a big batch
+
+### Decode (generate tokens one at a time)
+
+After prefill, tokens are generated **one at a time**, each fed back as input:
+
+```
+[prompt] → prefill → token₁
+[prompt, token₁] → decode → token₂
+[prompt, token₁, token₂] → decode → token₃
+...
+```
+
+- Input: 1 new token at a time
+- Compute: 1 token attending to all previous tokens
+- This is **memory-bandwidth-bound** — small compute per step, but lots of weight loading
+
+This is why TTFT (time to first token) and decode speed are measured separately — they stress different parts of the hardware.
+
+## 5. The KV Cache: Don't Redo Work
+
+Notice in decode, each new token needs to attend to ALL previous tokens. Naively, you'd recompute Q, K, V for every previous token on every step. That's wasteful.
+
+The **KV cache** stores the K and V vectors from all previous tokens. On each new step, you only compute Q, K, V for the new token, then append its K and V to the cache.
+
+```
+Step 1: compute K₁, V₁, cache them
+Step 2: compute K₂, V₂, cache them. Attend using [K₁,K₂] and [V₁,V₂]
+Step 3: compute K₃, V₃, cache them. Attend using [K₁,K₂,K₃] and [V₁,V₂,V₃]
+```
+
+The cache grows with sequence length. For a 7B model generating 1024 tokens, the KV cache alone can be several GB.
+
+**Cache variants:**
+- **Standard KVCache** — unbounded, grows with every token
+- **RotatingKVCache** — fixed-size sliding window, old entries get overwritten (used by models with sliding window attention like Mistral)
+- **ArraysCache** — for non-transformer layers (SSM/linear attention) that store recurrent state instead of K/V pairs
+
+## 6. Quantization: Shrink the Weights
+
+A 7B parameter model at full precision (float32, 32 bits per number) = 28 GB. That's a lot of memory to load for every forward pass.
+
+**Quantization** stores weights in fewer bits:
+
+| Precision | Bits | 7B model size | Quality |
+|-----------|------|---------------|---------|
+| float32 | 32 | 28 GB | Full |
+| float16 | 16 | 14 GB | Near-full |
+| 8-bit | 8 | 7 GB | Slight loss |
+| 4-bit | 4 | 3.5 GB | Noticeable loss |
+
+The model weights are stored quantized (compressed), and **dequantized** (decompressed) on the fly during computation.
+
+This matters for performance because:
+- **Less memory** = model fits on your device
+- **Less bandwidth** = weights load faster from memory to compute units
+- Decode is memory-bandwidth-bound, so smaller weights → faster decode
+
+**Quantized SDPA** is a special codepath where the attention computation works directly on quantized KV cache values, avoiding the dequantize step. This is faster but requires careful implementation.
+
+**Mixed-precision quantization** (like OptiQ) quantizes different layers at different bit widths — e.g., attention layers at 8-bit, MLP layers at 4-bit — balancing quality and size.
+
+## 7. Lazy Evaluation: MLX's Trick
+
+MLX (Apple's ML framework) uses **lazy evaluation**. When you write:
+
+```python
+y = mx.matmul(a, b)
+z = mx.add(y, c)
+```
+
+Nothing actually computes yet. MLX builds a computation graph. The math only runs when you call `mx.eval(z)`.
+
+Why this matters for performance:
+- MLX can **fuse operations** — instead of matmul→store→load→add, it can do matmul+add in one pass
+- Bad `mx.eval()` placement = suboptimal fusion
+  - **Too many evals** = too many GPU sync points, overhead from launching many small kernels
+  - **Too few evals** = computation graph grows huge, uses lots of memory to track intermediate results
+
+This is an implementation detail that directly affects benchmark numbers — same math, different eval placement, different speed.
+
+## 8. Fused Kernels: Why Op Selection Matters
+
+A **kernel** is a function that runs on the GPU. A **fused kernel** combines multiple operations into one GPU call.
+
+Example — attention without fusion:
+```
+1. Q × K^T  → store result to memory
+2. divide by √d → load, compute, store
+3. softmax → load, compute, store
+4. multiply by V → load, compute, store
+```
+
+Each step reads from and writes to memory. Memory access is slow.
+
+Fused attention (`mx.fast.scaled_dot_product_attention`):
+```
+1. Q × K^T → divide → softmax → × V  (all in one kernel, data stays in fast on-chip memory)
+```
+
+Same math, ~2-4x faster, because data stays close to the compute units instead of bouncing through main memory.
+
+When an mlx-lm model file uses the fused path vs manual implementation, it directly impacts the numbers you see in benchmarks.
+
+## 9. Memory Bandwidth: The Real Bottleneck
+
+Apple Silicon uses **unified memory** — CPU and GPU share the same RAM. The key spec is **memory bandwidth** (how fast data moves from memory to compute units).
+
+| Chip | Memory Bandwidth |
+|------|-----------------|
+| M1 | 68 GB/s |
+| M1 Pro/Max | 200-400 GB/s |
+| M2 Ultra | 800 GB/s |
+| M4 Pro | 273 GB/s |
+
+During decode (one token at a time), the GPU must load ALL model weights from memory for each token. A 4-bit 7B model = ~3.5 GB of weights loaded per token.
+
+At 200 GB/s bandwidth: 3.5 GB / 200 GB/s = 0.0175s per token → ~57 tokens/sec theoretical max.
+
+This is why:
+- Smaller models are faster (less to load)
+- Quantization helps (smaller weights = less to load)
+- Prefill is faster per-token than decode (batched tokens amortize the weight loading)
+- Our benchmark showed Qwen 0.8B at ~245 tok/s vs 9B at ~80 tok/s — roughly proportional to model size
+
+## 10. Putting It All Together: What mlx-lm Does
+
+When you run `mlx_lm.load("some-model")` + generate:
+
+1. **Download** weights from HuggingFace (quantized safetensors)
+2. **Load** weights into unified memory as MLX arrays
+3. **Build** the model by instantiating the Python module (`Model` class) with architecture-specific layers
+4. **Prefill** — process the prompt through all layers in one pass, populate the KV cache
+5. **Decode loop** — for each new token:
+   - Run forward pass on the single new token
+   - Attention reads from KV cache (all previous K/V) + new token's K/V
+   - Append new K/V to cache
+   - Project to vocabulary, pick next token
+   - Repeat until done or EOS
+
+The Python model file controls steps 3-5. The performance depends on:
+- Which MLX ops are used (fused vs manual)
+- How tensors are laid out in memory
+- Where `mx.eval()` calls are placed
+- What KV cache strategy is used
+- Whether quantized compute paths are used
+
+Two implementations of the same architecture can differ in all of these, which is why the implementation matters — not just the model and the hardware.
+
+## Glossary
+
+| Term | Meaning |
+|------|---------|
+| **TTFT** | Time to first token — measures prefill speed |
+| **Tokens/sec** | Decode throughput — tokens generated per second |
+| **GQA** | Grouped-query attention — K/V heads are shared across Q heads, reduces KV cache size |
+| **MQA** | Multi-query attention — all Q heads share one K/V head |
+| **MoE** | Mixture of experts — only a subset of parameters active per token (e.g., 26B total, 4B active) |
+| **RoPE** | Rotary position embedding — encodes token position into attention |
+| **SwiGLU** | Activation function used in modern LLMs (in the MLP) |
+| **SDPA** | Scaled dot-product attention — the core attention computation |
+| **EOS** | End of sequence token — signals the model to stop generating |

--- a/content/notes/llm-inference-from-scratch.md
+++ b/content/notes/llm-inference-from-scratch.md
@@ -40,29 +40,23 @@ Step by step:
 
 Each layer has two main parts: **Attention** and **MLP** (feed-forward network).
 
-### Attention: "What should I focus on?"
+### Attention: "Gather information from context"
 
-Given a sequence of tokens, attention lets each token look at all previous tokens and decide how much to "pay attention" to each one.
+After step 2, each token is a vector of numbers — but it's isolated. The word "cat" doesn't know that "sat" comes after it. Attention is the step where tokens talk to each other.
 
-Concretely:
-1. Each token gets transformed into three vectors: **Query (Q)**, **Key (K)**, **Value (V)**
-2. Q and K are multiplied together to get attention scores (which tokens are relevant to which)
-3. Scores are used to create a weighted mix of V vectors
-4. Result: each token now contains information from the tokens it attended to
+Take the sentence: **"The cat sat on the ___"**
 
-The math: `Attention(Q, K, V) = softmax(Q × K^T / √d) × V`
+The model needs to predict the blank. Each token gets to ask every token before it: "are you relevant to me?" The answers become scores, and each token becomes a weighted blend of the tokens it found most relevant.
 
-This is all matrix multiplications — the single most performance-critical operation.
+For "___", it might heavily attend to "cat" and "sat" — they tell it what the sentence is about. It barely attends to "the" or "on" — less informative. After attention, the blank token's vector now encodes context from the whole sequence, not just itself.
 
-### MLP: "Process what I focused on"
+**How the matching works (Q/K/V):** Each token gets transformed into three vectors — Query ("what am I looking for?"), Key ("what do I contain?"), and Value ("what information do I carry?"). Query and Key are compared to produce relevance scores, then those scores weight the Values. The math is all matrix multiplications, making it the most performance-critical operation. But you can treat Q/K/V as an implementation detail until you need to dig into the code.
 
-After attention, each token's vector goes through a feed-forward network:
+### MLP: "Process what I gathered"
 
-```
-input → Linear(expand) → activation → Linear(shrink) → output
-```
+After tokens have gathered context via attention, each token independently goes through a small neural network that transforms its vector. Think of attention as "gather information" and MLP as "process information."
 
-This expands the vector (e.g., 768 → 3072), applies a non-linearity, then shrinks it back. It's where the model stores and applies "knowledge."
+The MLP expands the vector (e.g., 768 → 3072 numbers), applies a non-linear function, then shrinks it back. This is where the model stores and applies factual knowledge.
 
 ### Residual Connections
 
@@ -73,7 +67,7 @@ output = input + attention(input)
 output = output + mlp(output)
 ```
 
-This "residual connection" is critical — without it, deep models can't train. It means information can skip layers if needed.
+This means information can skip steps if needed — a token can pass through a layer mostly unchanged if that layer isn't useful for it. Without residual connections, stacking 32+ layers deep wouldn't work.
 
 ## 4. Prefill vs Decode: Two Phases of Generation
 

--- a/content/notes/mlx-lm-model-bringup.md
+++ b/content/notes/mlx-lm-model-bringup.md
@@ -1,0 +1,110 @@
+---
+title: "mlx-lm Model Bringup Process"
+date: 2026-04-07T00:00:00+0800
+tags: [mlx, apple-silicon, llm, inference, model-support]
+---
+
+How new model architectures get added to [mlx-lm](https://github.com/ml-explore/mlx-examples/tree/main/llms/mlx_lm), Apple's MLX inference library for LLMs on Apple Silicon.
+
+## How Model Loading Works
+
+When you call `mlx_lm.load("some-model")`, the library:
+
+1. Downloads the model from HuggingFace (weights + `config.json`)
+2. Reads `model_type` from `config.json` (e.g., `"llama"`, `"qwen3_5"`, `"gemma4"`)
+3. Does `importlib.import_module(f"mlx_lm.models.{model_type}")` to find the architecture
+4. Expects the module to export `Model` and `ModelArgs` classes
+
+If there's no matching module, you get `ValueError: Model type X not supported`. This is what happens when a brand-new architecture (like Gemma 4) hasn't been implemented yet.
+
+There's also a `MODEL_REMAPPING` dict for aliases, so some model types map to existing implementations.
+
+## What a Model Module Must Implement
+
+Each architecture lives in its own file under `mlx_lm/models/`. The file must export:
+
+### `ModelArgs` (dataclass)
+- Subclass of `BaseModelArgs` (which provides `from_dict` for parsing `config.json`)
+- Declares all architecture hyperparameters: hidden size, number of layers, number of heads, vocab size, RoPE config, etc.
+
+### `Model` (nn.Module)
+- Standard interface: `__call__(self, inputs, cache=None, input_embeddings=None) -> logits`
+- `sanitize(self, weights)` — clean up weight names, drop unused keys (e.g., precomputed rotary freqs)
+- `make_cache()` — return the right KV cache type per layer
+- Optional: `shard()` for multi-device distributed inference
+
+### Internal Components (Attention, MLP, TransformerBlock)
+These vary by architecture, but the pattern is always:
+
+```
+Embedding → [TransformerBlock × N] → RMSNorm → LM Head
+```
+
+Where each TransformerBlock is:
+```
+Input → LayerNorm → Attention → Residual → LayerNorm → MLP → Residual
+```
+
+## Complexity Range
+
+Not all model files are equal:
+
+| Architecture | Lines | Why |
+|-------------|-------|-----|
+| Llama | ~274 | Standard dense transformer, the baseline everyone builds on |
+| Qwen3.5 | ~524 | Hybrid attention (full + linear/SSM), MoE routing, vision support, gated delta updates |
+| DeepSeek V3 | ~600+ | MoE with shared experts, multi-latent attention |
+
+Simple architectures that are Llama-like (Mistral, Yi, etc.) can reuse components or be thin wrappers. Genuinely new architectures (hybrid SSM+attention, novel MoE routing, new attention variants) require implementing the full forward pass from scratch in MLX ops.
+
+## Example Bringup PRs
+
+Looking at merged PRs in [ml-explore/mlx-examples](https://github.com/ml-explore/mlx-examples) gives a sense of the range:
+
+**Straightforward bringups** (model follows an existing pattern):
+- [#907 — Add support for Llama-3.1](https://github.com/ml-explore/mlx-examples/pull/907) — Llama family, mostly config changes
+- [#871 — Add support for InternLM-2.5](https://github.com/ml-explore/mlx-examples/pull/871) — Llama-like architecture
+- [#758 — Add support for IBM Granite](https://github.com/ml-explore/mlx-examples/pull/758) — standard dense transformer
+- [#1157 — Add support for Cohere2](https://github.com/ml-explore/mlx-examples/pull/1157) — iteration on existing Cohere support
+- [#1208 — Adding support for Kyutai Helium](https://github.com/ml-explore/mlx-examples/pull/1208)
+
+**Non-trivial bringups** (new architecture concepts):
+- [#940 — Adding support for Mamba](https://github.com/ml-explore/mlx-examples/pull/940) — SSM architecture, fundamentally different from transformers, needs custom state management instead of KV cache
+- [#1336 — Add support for Gemma3](https://github.com/ml-explore/mlx-examples/pull/1336) — sliding window + global attention hybrid, logit soft-capping
+- [#1191 — DeepSeek V3 with pipeline parallelism](https://github.com/ml-explore/mlx-examples/pull/1191) — MoE with shared experts, multi-latent attention, required pipeline parallelism for the model to fit
+- [#685 — MiniCPM implementation](https://github.com/ml-explore/mlx-examples/pull/685)
+
+**Follow-up fixes** (bringup isn't done at merge):
+- [#1229 — Better overflow correction for DeepSeek V3](https://github.com/ml-explore/mlx-examples/pull/1229) — numerical stability issues found post-merge
+- [#1242 — Fix DeepSeek sharding](https://github.com/ml-explore/mlx-examples/pull/1242) — distributed inference bugs
+
+The follow-up PRs are worth noting: initial bringup often gets the forward pass working, but edge cases in quantization, sharding, and numerical precision surface later.
+
+## What Makes Bringup Non-Trivial
+
+1. **Weight mapping** — HuggingFace weight names don't always match 1:1 with the MLX module structure. The `sanitize()` method handles renames, drops, and reshapes. Getting this wrong means silent correctness bugs.
+
+2. **Attention variants** — GQA, MQA, sliding window, linear attention, sparse attention all need different implementations. MLX provides `mx.fast.scaled_dot_product_attention` for standard SDPA but anything novel needs manual implementation.
+
+3. **RoPE variants** — Different models use different positional encoding schemes (standard, NTK-aware, YaRN, dynamic). The `rope_utils.py` helper handles common ones but new variants may need additions.
+
+4. **KV cache types** — Standard `KVCache` vs `RotatingKVCache` (for sliding window) vs `ArraysCache` (for SSM/linear attention state). Hybrid models like Qwen3.5 use different cache types for different layers.
+
+5. **Quantization compatibility** — The model must work with MLX's quantization. Quantized SDPA has its own codepath (`quantized_scaled_dot_product_attention`) that requires specific tensor layouts.
+
+## Shared Infrastructure
+
+Model files don't start from zero. `mlx_lm/models/` provides:
+
+- `base.py` — `BaseModelArgs`, causal mask creation, SDPA (both standard and quantized)
+- `cache.py` — `KVCache`, `RotatingKVCache`, `ArraysCache`
+- `rope_utils.py` — RoPE initialization for common scaling schemes
+- `activations.py` — SwiGLU and other activation functions
+
+Models can also import from each other. Qwen3.5 imports its attention and MLP from `qwen3_next`, and many models are thin adaptations of the Llama implementation.
+
+## Practical Takeaway
+
+If a model uses a known architecture (Llama-family, Mistral-family, Qwen-family), it's likely already supported or trivial to add. If it introduces a genuinely new mechanism (new attention pattern, novel MoE routing, hybrid SSM), expect 300-600 lines of new MLX code plus careful weight mapping work.
+
+Check `mlx_lm/models/` for the ~117 currently supported architectures before assuming something isn't supported — many model families share implementations under remapped names.


### PR DESCRIPTION
## Summary
- **mlx-lm model bringup**: Documents how new model architectures get added to Apple's mlx-lm library — module interface, complexity range, and references to real merged PRs from ml-explore/mlx-examples
- **LLM inference from scratch**: Builds from basic concepts (tensors, forward pass) up to understanding model serving on Apple Silicon — covers prefill/decode, KV cache, quantization, fused kernels, and memory bandwidth

## Context
Written while benchmarking MLX models and hitting `Model type gemma4 not supported` — wanted to document both the bringup process and the fundamentals needed to understand why implementation choices affect benchmark numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)