### PR TITLE
Merge homepage sections into one Latest Writing feed

### DIFF
--- a/build.js
+++ b/build.js
@@ -178,8 +178,9 @@ function articleListItem(article) {
     </li>`;
 }
 
-// Type badge shown in the merged homepage feed. Ink is tinted per type; the
-// chip shape matches the tag badges on article/note/experiment pages.
+// Type badge shown in the merged homepage feed: a lowercase outline pill, kept
+// quieter than the filled tag badges on the article/note/experiment pages so it
+// reads as a marker rather than a label. Ink is tinted per type.
 const FEED_TYPES = {
   article: { label: 'article', dir: 'articles', ink: 'text-[#4b5563] dark:text-[#cbd5e1]' },
   note: { label: 'note', dir: 'notes', ink: 'text-[#7c6f52] dark:text-[#cbb994]' },
@@ -193,7 +194,7 @@ function feedListItem(item) {
   return `<li class="flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-4">
       <span class="flex items-center gap-2 sm:w-28 sm:shrink-0 sm:flex-col sm:items-start sm:gap-1">
         <time class="text-sm leading-none text-gray-500 dark:text-gray-400 tabular-nums" datetime="${item.date.toISOString()}">${formatDateShort(item.date)}</time>
-        <span class="text-[0.66rem] leading-none uppercase tracking-wide px-1.5 py-1 rounded bg-gray-100 dark:bg-gray-800 ${kind.ink}">${kind.label}</span>
+        <span class="text-[0.7rem] leading-none px-1.5 py-1 rounded-full border border-gray-200 dark:border-gray-700 ${kind.ink}">${kind.label}</span>
       </span>
       <a href="/${kind.dir}/${item.slug}/" class="leading-snug hover:opacity-75 transition-opacity">${escapeXml(item.title)}</a>
     </li>`;

--- a/build.js
+++ b/build.js
@@ -178,10 +178,34 @@ function articleListItem(article) {
     </li>`;
 }
 
+// Type badge shown in the merged homepage feed. Ink is tinted per type; the
+// chip shape matches the tag badges on article/note/experiment pages.
+const FEED_TYPES = {
+  article: { label: 'article', dir: 'articles', ink: 'text-[#4b5563] dark:text-[#cbd5e1]' },
+  note: { label: 'note', dir: 'notes', ink: 'text-[#7c6f52] dark:text-[#cbb994]' },
+  experiment: { label: 'experiment', dir: 'experiments', ink: 'text-[#4d6b7c] dark:text-[#93c0d6]' },
+};
+
+function feedListItem(item) {
+  const kind = FEED_TYPES[item.type];
+  return `<li class="flex items-baseline gap-4">
+      <span class="shrink-0 w-28 flex flex-col items-start gap-0.5">
+        <time class="text-sm text-gray-500 dark:text-gray-400 tabular-nums" datetime="${item.date.toISOString()}">${formatDateShort(item.date)}</time>
+        <span class="text-[0.66rem] uppercase tracking-wide px-1.5 rounded bg-gray-100 dark:bg-gray-800 ${kind.ink}">${kind.label}</span>
+      </span>
+      <a href="/${kind.dir}/${item.slug}/" class="hover:opacity-75 transition-opacity">${escapeXml(item.title)}</a>
+    </li>`;
+}
+
 function homePage(articles, notes, experiments) {
-  const latestArticles = articles.slice(0, 3);
-  const latestNotes = notes.slice(0, 3);
-  const latestExperiments = experiments.slice(0, 3);
+  const feed = [
+    ...articles.map(a => ({ ...a, type: 'article' })),
+    ...notes.map(n => ({ ...n, type: 'note' })),
+    ...experiments.map(e => ({ ...e, type: 'experiment' })),
+  ]
+    .sort((a, b) => b.date - a.date)
+    .slice(0, 10);
+
   return baseLayout(SITE_TITLE, `
     <section class="mb-12">
       <div class="flex gap-4 mb-8">
@@ -198,27 +222,10 @@ function homePage(articles, notes, experiments) {
     </section>
 
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-6">Latest Articles</h2>
-      <ul class="space-y-3 mb-6">
-        ${latestArticles.map(articleListItem).join('\n        ')}
+      <h2 class="text-xl font-semibold mb-6">Latest Writing</h2>
+      <ul class="space-y-4">
+        ${feed.map(feedListItem).join('\n        ')}
       </ul>
-      <a href="/articles/" class="text-sm hover:opacity-75 transition-opacity">View all &rarr;</a>
-    </section>
-
-    <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-6">Latest Notes</h2>
-      <ul class="space-y-3 mb-6">
-        ${latestNotes.map(noteListItem).join('\n        ')}
-      </ul>
-      <a href="/notes/" class="text-sm hover:opacity-75 transition-opacity">View all &rarr;</a>
-    </section>
-
-    <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-6">Latest Experiments</h2>
-      <ul class="space-y-3 mb-6">
-        ${latestExperiments.map(experimentListItem).join('\n        ')}
-      </ul>
-      <a href="/experiments/" class="text-sm hover:opacity-75 transition-opacity">View all &rarr;</a>
     </section>
 
     <section class="mt-16 flex justify-center">

--- a/build.js
+++ b/build.js
@@ -146,9 +146,9 @@ function baseLayout(title, content, { isHome = false } = {}) {
   </style>
 </head>
 <body class="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 transition-colors duration-200 min-h-screen flex flex-col text-base lg:text-lg">
-  <header class="max-w-2xl mx-auto w-full px-6 py-8 flex items-center justify-between">
+  <header class="max-w-2xl mx-auto w-full px-6 py-6 sm:py-8 flex flex-wrap items-center justify-between gap-y-2">
     <a href="/" class="text-lg font-semibold hover:opacity-75 transition-opacity">${escapeXml(SITE_TITLE)}</a>
-    <nav class="flex items-center gap-6">
+    <nav class="flex items-center gap-4 sm:gap-6 text-sm sm:text-base">
       <a href="/articles/" class="hover:opacity-75 transition-opacity">Articles</a>
       <a href="/notes/" class="hover:opacity-75 transition-opacity">Notes</a>
       <a href="/experiments/" class="hover:opacity-75 transition-opacity">Experiments</a>
@@ -186,14 +186,16 @@ const FEED_TYPES = {
   experiment: { label: 'experiment', dir: 'experiments', ink: 'text-[#4d6b7c] dark:text-[#93c0d6]' },
 };
 
+// Date and badge sit side by side on narrow screens with the title beneath, and
+// stack into a fixed left column from sm up so the titles align.
 function feedListItem(item) {
   const kind = FEED_TYPES[item.type];
-  return `<li class="flex items-baseline gap-4">
-      <span class="shrink-0 w-28 flex flex-col items-start gap-0.5">
-        <time class="text-sm text-gray-500 dark:text-gray-400 tabular-nums" datetime="${item.date.toISOString()}">${formatDateShort(item.date)}</time>
-        <span class="text-[0.66rem] uppercase tracking-wide px-1.5 rounded bg-gray-100 dark:bg-gray-800 ${kind.ink}">${kind.label}</span>
+  return `<li class="flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-4">
+      <span class="flex items-center gap-2 sm:w-28 sm:shrink-0 sm:flex-col sm:items-start sm:gap-1">
+        <time class="text-sm leading-none text-gray-500 dark:text-gray-400 tabular-nums" datetime="${item.date.toISOString()}">${formatDateShort(item.date)}</time>
+        <span class="text-[0.66rem] leading-none uppercase tracking-wide px-1.5 py-1 rounded bg-gray-100 dark:bg-gray-800 ${kind.ink}">${kind.label}</span>
       </span>
-      <a href="/${kind.dir}/${item.slug}/" class="hover:opacity-75 transition-opacity">${escapeXml(item.title)}</a>
+      <a href="/${kind.dir}/${item.slug}/" class="leading-snug hover:opacity-75 transition-opacity">${escapeXml(item.title)}</a>
     </li>`;
 }
 
@@ -207,8 +209,16 @@ function homePage(articles, notes, experiments) {
     .slice(0, 10);
 
   return baseLayout(SITE_TITLE, `
-    <section class="mb-12">
-      <div class="flex gap-4 mb-8">
+    <section>
+      <h2 class="text-xl font-semibold mb-6">Latest Writing</h2>
+      <ul class="space-y-5 sm:space-y-3">
+        ${feed.map(feedListItem).join('\n        ')}
+      </ul>
+    </section>
+
+    <section class="mt-16 flex flex-col items-center gap-5">
+      <img src="/images/sprite.svg" alt="Pixel art avatar" class="w-20 h-20" style="image-rendering: pixelated;" />
+      <div class="flex gap-4">
         <a href="https://github.com/pokgak" class="text-gray-500 hover:text-gray-900 dark:hover:text-gray-100 transition-colors" aria-label="GitHub">
           <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
         </a>
@@ -219,17 +229,6 @@ function homePage(articles, notes, experiments) {
           <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24"><path d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z"/></svg>
         </a>
       </div>
-    </section>
-
-    <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-6">Latest Writing</h2>
-      <ul class="space-y-4">
-        ${feed.map(feedListItem).join('\n        ')}
-      </ul>
-    </section>
-
-    <section class="mt-16 flex justify-center">
-      <img src="/images/sprite.svg" alt="Pixel art avatar" class="w-20 h-20" style="image-rendering: pixelated;" />
     </section>
   `, { isHome: true });
 }


### PR DESCRIPTION
Articles, notes and experiments were three separate capped sections, so the
newest item could sit below older ones. They now merge into a single
date-sorted list of 10, with a type chip stacked under each date so the
source is still obvious at a glance.

Talks stay off the homepage — fewer of them, and their dates run years
behind the writing. All per-type list pages and the nav are unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012RjbiPMgMjcbDRwnBL9JPx