### PR TITLE
Improve site accessibility and screen-reader support

### DIFF
--- a/build.js
+++ b/build.js
@@ -14,7 +14,7 @@ renderer.code = function (code, lang) {
   } else {
     highlighted = hljs.highlightAuto(code).value;
   }
-  return `<pre><code class="hljs language-${lang}">${highlighted}</code></pre>`;
+  return `<pre tabindex="0"><code class="hljs language-${lang}">${highlighted}</code></pre>`;
 };
 marked.use({ renderer });
 
@@ -65,6 +65,16 @@ function escapeXml(str) {
   return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
+function normalizeLang(lang) {
+  const value = typeof lang === 'string' ? lang.trim() : 'en';
+  return /^[a-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$/.test(value) ? value : 'en';
+}
+
+function navLink(href, label, section, currentSection) {
+  const current = section === currentSection ? ' aria-current="page"' : '';
+  return `<a href="${href}" class="hover:opacity-75 transition-opacity"${current}>${label}</a>`;
+}
+
 // --- Load content ---
 
 function loadTalks(dir) {
@@ -83,6 +93,7 @@ function loadTalks(dir) {
       embed_url: data.embed_url || '',
       slides_pdf: data.slides_pdf || '',
       thumbnail: data.thumbnail || '',
+      lang: normalizeLang(data.lang),
       slug,
       html,
     };
@@ -104,6 +115,7 @@ function loadContent(dir) {
       title: data.title || slug,
       date: data.date ? new Date(data.date) : new Date(0),
       tags: data.tags || [],
+      lang: normalizeLang(data.lang),
       slug,
       html,
       content: fixedContent,
@@ -115,10 +127,10 @@ function loadContent(dir) {
 
 // --- Templates ---
 
-function baseLayout(title, content, { isHome = false } = {}) {
+function baseLayout(title, content, { lang = 'en', currentSection = '' } = {}) {
   const pageTitle = title;
   return `<!DOCTYPE html>
-<html lang="en" x-data="{ dark: localStorage.getItem('dark') === 'true' }" x-init="$watch('dark', v => { localStorage.setItem('dark', v); document.getElementById('hljs-light').disabled = v; document.getElementById('hljs-dark').disabled = !v; }); document.getElementById('hljs-light').disabled = dark; document.getElementById('hljs-dark').disabled = !dark;" :class="{ 'dark': dark }">
+<html lang="${escapeXml(normalizeLang(lang))}" x-data="{ dark: localStorage.getItem('dark') === 'true' }" x-init="$watch('dark', v => { localStorage.setItem('dark', v); document.getElementById('hljs-light').disabled = v; document.getElementById('hljs-dark').disabled = !v; }); document.getElementById('hljs-light').disabled = dark; document.getElementById('hljs-dark').disabled = !dark;" :class="{ 'dark': dark }">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -139,28 +151,31 @@ function baseLayout(title, content, { isHome = false } = {}) {
     .prose pre { @apply rounded-lg overflow-x-auto; max-width: 100%; }
     .prose pre code { font-size: 0.875em; white-space: pre; word-wrap: normal; overflow-wrap: normal; }
     .prose pre { padding: 0 !important; background-color: transparent !important; }
-    .prose pre code.hljs { color: #24292e; background: #f6f8fa; display: block; padding: 1em; border-radius: 0.5rem; }
+    .prose pre code.hljs { color: #24292e; background: #f6f8fa; display: block; overflow-x: visible; padding: 1em; border-radius: 0.5rem; }
     .dark .prose pre code.hljs { color: #c9d1d9; background: #0d1117; }
     .prose img { @apply rounded-lg mx-auto; }
     .prose a { @apply underline decoration-gray-400 dark:decoration-gray-500 underline-offset-2 hover:decoration-gray-800 dark:hover:decoration-gray-200 transition-colors; }
+    :focus-visible { outline: 3px solid #2563eb; outline-offset: 3px; }
+    .dark :focus-visible { outline-color: #60a5fa; }
   </style>
 </head>
 <body class="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 transition-colors duration-200 min-h-screen flex flex-col text-base lg:text-lg">
-  <header class="max-w-2xl mx-auto w-full px-6 py-8 flex items-center justify-between">
+  <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-white focus:px-4 focus:py-2 focus:text-gray-900 focus:shadow-lg dark:focus:bg-gray-800 dark:focus:text-white">Skip to content</a>
+  <header class="max-w-2xl mx-auto w-full px-6 py-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
     <a href="/" class="text-lg font-semibold hover:opacity-75 transition-opacity">${escapeXml(SITE_TITLE)}</a>
-    <nav class="flex items-center gap-6">
-      <a href="/articles/" class="hover:opacity-75 transition-opacity">Articles</a>
-      <a href="/notes/" class="hover:opacity-75 transition-opacity">Notes</a>
-      <a href="/experiments/" class="hover:opacity-75 transition-opacity">Experiments</a>
-      <a href="/talks/" class="hover:opacity-75 transition-opacity">Talks</a>
-      <button @click="dark = !dark" class="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors" aria-label="Toggle dark mode">
-        <svg x-show="!dark" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
-        <svg x-show="dark" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+    <nav class="flex flex-wrap items-center gap-x-4 gap-y-3 sm:gap-6" aria-label="Primary">
+      ${navLink('/articles/', 'Articles', 'articles', currentSection)}
+      ${navLink('/notes/', 'Notes', 'notes', currentSection)}
+      ${navLink('/experiments/', 'Experiments', 'experiments', currentSection)}
+      ${navLink('/talks/', 'Talks', 'talks', currentSection)}
+      <button type="button" @click="dark = !dark" class="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors" aria-pressed="false" aria-label="Enable dark mode" :aria-pressed="dark.toString()" :aria-label="dark ? 'Disable dark mode' : 'Enable dark mode'">
+        <svg x-show="!dark" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+        <svg x-show="dark" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
       </button>
     </nav>
   </header>
 
-  <main class="max-w-2xl mx-auto w-full px-6 flex-1">
+  <main id="main-content" tabindex="-1" class="max-w-2xl mx-auto w-full px-6 flex-1">
     ${content}
   </main>
 
@@ -186,16 +201,18 @@ function homePage(articles, notes, experiments) {
     <section class="mb-12">
       <div class="flex gap-4 mb-8">
         <a href="https://github.com/pokgak" class="text-gray-500 hover:text-gray-900 dark:hover:text-gray-100 transition-colors" aria-label="GitHub">
-          <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+          <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
         </a>
         <a href="https://www.linkedin.com/in/aiman-ismail-704158214/" class="text-gray-500 hover:text-gray-900 dark:hover:text-gray-100 transition-colors" aria-label="LinkedIn">
-          <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+          <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
         </a>
         <a href="https://twitter.com/pokgak73" class="text-gray-500 hover:text-gray-900 dark:hover:text-gray-100 transition-colors" aria-label="Twitter">
-          <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24"><path d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z"/></svg>
+          <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z"/></svg>
         </a>
       </div>
     </section>
+
+    <h1 class="text-2xl font-semibold mb-8">Latest Writing</h1>
 
     <section class="mb-12">
       <h2 class="text-xl font-semibold mb-6">Latest Articles</h2>
@@ -222,9 +239,9 @@ function homePage(articles, notes, experiments) {
     </section>
 
     <section class="mt-16 flex justify-center">
-      <img src="/images/sprite.svg" alt="Pixel art avatar" class="w-20 h-20" style="image-rendering: pixelated;" />
+      <img src="/images/sprite.svg" alt="Pixel art portrait of Aiman Ismail" class="w-20 h-20" style="image-rendering: pixelated;" />
     </section>
-  `, { isHome: true });
+  `);
 }
 
 function articlesListPage(articles) {
@@ -233,7 +250,7 @@ function articlesListPage(articles) {
     <ul class="space-y-3">
       ${articles.map(articleListItem).join('\n      ')}
     </ul>
-  `);
+  `, { currentSection: 'articles' });
 }
 
 function articlePage(article) {
@@ -257,7 +274,7 @@ function articlePage(article) {
         ${article.html}
       </div>
     </article>
-  `);
+  `, { lang: article.lang, currentSection: 'articles' });
 }
 
 function noteListItem(note) {
@@ -274,7 +291,7 @@ function notesListPage(notes) {
     <ul class="space-y-3">
       ${notes.map(noteListItem).join('\n      ')}
     </ul>
-  `);
+  `, { currentSection: 'notes' });
 }
 
 function notePage(note) {
@@ -299,7 +316,7 @@ function notePage(note) {
         ${note.html}
       </div>
     </article>
-  `);
+  `, { lang: note.lang, currentSection: 'notes' });
 }
 
 function experimentListItem(experiment) {
@@ -317,7 +334,7 @@ function experimentsListPage(experiments) {
     <ul class="space-y-3">
       ${experiments.map(experimentListItem).join('\n      ')}
     </ul>
-  `);
+  `, { currentSection: 'experiments' });
 }
 
 function experimentPage(experiment) {
@@ -342,13 +359,13 @@ function experimentPage(experiment) {
         ${experiment.html}
       </div>
     </article>
-  `);
+  `, { lang: experiment.lang, currentSection: 'experiments' });
 }
 
 function talkListItem(talk) {
   const thumb = talk.thumbnail
     ? `<a href="/talks/${talk.slug}/" class="block mb-3 hover:opacity-75 transition-opacity">
-        <img src="/images/${escapeXml(talk.thumbnail)}" alt="${escapeXml(talk.title)}" class="w-full rounded-lg aspect-video object-cover">
+        <img src="/images/${escapeXml(talk.thumbnail)}" alt="" class="w-full rounded-lg aspect-video object-cover">
       </a>`
     : '';
   return `<li class="flex flex-col gap-1">
@@ -367,13 +384,13 @@ function talksListPage(talks) {
     <ul class="space-y-6">
       ${talks.map(talkListItem).join('\n      ')}
     </ul>
-  `);
+  `, { currentSection: 'talks' });
 }
 
 function talkPage(talk) {
   const embed = talk.embed_url
     ? `<div class="relative w-full mb-8" style="padding-top: 56.25%;">
-        <iframe src="${escapeXml(talk.embed_url)}" frameborder="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"
+        <iframe src="${escapeXml(talk.embed_url)}" title="${escapeXml(talk.title)} presentation slides" allowfullscreen
           class="absolute inset-0 w-full h-full rounded-lg"></iframe>
       </div>`
     : talk.thumbnail
@@ -382,7 +399,7 @@ function talkPage(talk) {
 
   const pdfLink = talk.slides_pdf
     ? `<a href="${escapeXml(talk.slides_pdf)}" class="inline-flex items-center gap-1 text-sm hover:opacity-75 transition-opacity" download>
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3M3 17V7a2 2 0 012-2h6l2 2h4a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"/></svg>
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3M3 17V7a2 2 0 012-2h6l2 2h4a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"/></svg>
         Download PDF
       </a>`
     : '';
@@ -409,7 +426,7 @@ function talkPage(talk) {
       ${pdfLink}
       ${body}
     </article>
-  `);
+  `, { lang: talk.lang, currentSection: 'talks' });
 }
 
 function rssFeed(articles) {

--- a/content/articles/alkisah-syarikat-a.md
+++ b/content/articles/alkisah-syarikat-a.md
@@ -1,6 +1,7 @@
 ---
 title: "Alkisah Syarikat A"
 date: 2021-08-26T18:24:00+08:00
+lang: ms
 tags: [Cloud Computing, Cerpen]
 draft: true
 ---

--- a/content/articles/auto-update-citf-graphs.md
+++ b/content/articles/auto-update-citf-graphs.md
@@ -1,6 +1,7 @@
 ---
 title: "Auto-update Graf Covid-19 menggunakan Github Actions"
 date: 2021-09-02T09:56:10+08:00
+lang: ms
 tags: [Github Actions, CI/CD]
 ---
 
@@ -139,7 +140,7 @@ Seperti yang anda boleh lihat, mudah sahaja cara penggunaan actions ini. Kita ha
 
 Sejak adanya workflow ini, saya tidak perlu lagi memastikan graf yang saya hasilkan di [pokgak/citf-graphs](https://github.com/pokgak/citf-graphs) sentiasa dikemaskini dengan maklumat terbaru secara manual, semuanya dilakukan secara automatik. Sejak itu juga, Github menunjukkan aktiviti saya aktif setiap hari, walaupun pada hakikatnya itu semua adalah bot sahaja :p
 
-![Cuba teka bila saya mula pakai workflow ni?](images/github-activity.png)
+![Graf sumbangan GitHub meningkat dengan ketara selepas workflow kemas kini automatik mula digunakan](images/github-activity.png)
 
 
 [1]: https://pokgak.xyz/articles/graf-interaktif-citf-plotly/

--- a/content/articles/blockhain.md
+++ b/content/articles/blockhain.md
@@ -1,6 +1,7 @@
 ---
 title: "Teknologi Blockchain"
 date: 2021-10-16T12:37:25+08:00
+lang: ms
 draft: true
 ---
 

--- a/content/articles/cloud-computing.md
+++ b/content/articles/cloud-computing.md
@@ -1,6 +1,7 @@
 ---
 title: "Apa itu Cloud Computing?"
 date: 2021-08-25T23:47:19+08:00
+lang: ms
 tags: [Cloud Computing]
 ---
 

--- a/content/articles/docker-bake.md
+++ b/content/articles/docker-bake.md
@@ -201,7 +201,7 @@ Finally, we managed to build a multi-platform image using docker buildx bake!
 
 ## well ackshually
 
-![](images/well-ackchyually.png)
+![“Well, ackchyually” meme](images/well-ackchyually.png)
 
 > you can just use docker multi-stage build
 
@@ -219,5 +219,4 @@ TLDR here's what I had to do to get multi-platform build working when using mult
 1. Build the image using `docker buildx bake`
 
 This use case is quite niche tbh and like I've said it is avoidable by using multi-stage builds but it is what it is. There's other use cases for Bake as described in this [guide](https://docs.docker.com/guides/bake/) that is more practical. It's worth a read IMO. Hope you've learnt something new as I have.
-
 

--- a/content/articles/eliminating-cross-az-traffic-cost.md
+++ b/content/articles/eliminating-cross-az-traffic-cost.md
@@ -10,7 +10,7 @@ Imagine going through your AWS bills and noticing that **APS1-DataTransfer-Regio
 
 ## The Traffic Flow
 
-![](images/cross-az-traffic.png)
+![Before-and-after traffic flow across three availability zones: cross-zone paths are replaced by zone-local load balancer, ingress-nginx, and pod paths](images/cross-az-traffic.png)
 
 In this article I will use the above diagram as our example network flow. Our example scenario will use the AWS Network Load Balancer (NLB) as the load balancer (LB), then routes the traffic to the ingress-nginx pods running inside our cluster. Finally, ingress-controller pods will route the traffic to the backend services serving the API.
 

--- a/content/articles/explain-k8s-dns.md
+++ b/content/articles/explain-k8s-dns.md
@@ -6,7 +6,7 @@ tags: [interview, kubernetes, dns, networking]
 
 This will be the first in my interview questions series. I'll compile interesting questions that I got from my experience interviewing for DevOps/SRE role in Malaysia.
 
-![](images/k8s-dns.png)
+![Kubernetes DNS request flow from a pod through CoreDNS, kube-proxy, and iptables to a Service endpoint](images/k8s-dns.png)
 
 ## Calling a service by its cluster-internal DNS
 

--- a/content/articles/exploring-alb-ingress-controller.md
+++ b/content/articles/exploring-alb-ingress-controller.md
@@ -8,7 +8,7 @@ Recently, [my company got DDoS'ed](https://pokgak.xyz/articles/we-got-ddosed/) a
 
 ## Current Setup
 
-![AWS NLB with ingress-nginx](images/lb-nlb-ingress-nginx.png)
+![AWS NLB routing through three ingress-nginx instances to five backend services](images/lb-nlb-ingress-nginx.png)
 
 Our current setup uses a AWS NLB per country to accepts the connection from the internet. The NLB then forwards the requests to a target group consisting all the ingress-nginx controller pods. The ingress-nginx pods will then route the traffic from NLB to the backend services based on the configured Ingress configurations.
 
@@ -16,7 +16,7 @@ For arguments sake, let's assume that AWS NLB is reliable and can scale infinite
 
 ## Proposed Setup
 
-![AWS ALB without ingress-nginx](images/lb-alb.png)
+![AWS ALB routing directly to five backend services without ingress-nginx](images/lb-alb.png)
 
 Our proposed setup uses the ALB directly and route traffic to the backend services through its listener rules. By default the aws-load-balancer controller will provision one ALB for each Ingress resource but we can share the ALB for multiple Ingress by specifying the same `alb.ingress.kubernetes.io/group.name`. In my case there will be one group name for each country resulting in separate ALB created for each respectively. Each Ingress resource will create a separate listener rule based on the host and path configuration specified in the Ingress.
 

--- a/content/articles/graf-interaktif-citf-plotly.md
+++ b/content/articles/graf-interaktif-citf-plotly.md
@@ -1,6 +1,7 @@
 ---
 title: "Animasi interaktif berdasarkan data CITF menggunakan Plotly"
 date: 2021-08-25T04:59:55+08:00
+lang: ms
 ---
 
 Saya gemar melayari subreddit r/dataisbeautiful dan melihat graf hasil buatan pengguna Reddit lain di sana. Salah satu jenis graf yang saya paling minat adalah apabila graf itu seolah-olah animasi, berubah selaras mengikut jangka masa waktu yang semakin bertambah. Kita boleh melihat perkembangan sesuatu data itu dari mula hingga ke akhir. 
@@ -8,7 +9,7 @@ Saya gemar melayari subreddit r/dataisbeautiful dan melihat graf hasil buatan pe
 Contoh post terbaru di subreddit itu yang mempunyai graf sebegini adalah seperti graf di bawah yang memaparkan Kadar vaksinasi sebahagian daripada negara-negara di seluruh dunia (*sayang Malaysia tidak dimasukkan sekali di sini*):
 
 {{< rawhtml >}}
-<iframe id="reddit-embed" src="https://www.redditmedia.com/r/dataisbeautiful/comments/p7l5rm/oc_the_race_to_vaccinate/?ref_source=embed&amp;ref=share&amp;embed=true" sandbox="allow-scripts allow-same-origin allow-popups" style="border: none;" height="620" width="640" scrolling="no"></iframe>
+<iframe id="reddit-embed" src="https://www.redditmedia.com/r/dataisbeautiful/comments/p7l5rm/oc_the_race_to_vaccinate/?ref_source=embed&amp;ref=share&amp;embed=true" title="Animasi kadar vaksinasi negara-negara di seluruh dunia" sandbox="allow-scripts allow-same-origin allow-popups" style="border: none;" height="620" width="640" scrolling="no"></iframe>
 {{< /rawhtml >}}
 
 Sebelum ini saya menganggap animasi sebegini rumit untuk dilakukan tetapi apabila pihak CITF telah melancarkan [public repo](https://twitter.com/Khairykj/status/1410164953965752331?s=20) di Github bagi data vaksinasi Malaysia, saya memutuskan untuk cuba menghasilkan semula gaya visualisasi ini menggunakan data tersebut.
@@ -16,7 +17,7 @@ Sebelum ini saya menganggap animasi sebegini rumit untuk dilakukan tetapi apabil
 Seterusnya saya akan menerangkan langkah-langkah yang diperlukan untuk menghasilkan visualisasi seperti yang di bawah. Sebagai rujukan, code penuh yang saya gunakan di sini boleh didapati di [sini](https://github.com/pokgak/citf-graphs/blob/main/main.py).
 
 {{< rawhtml >}}
-<iframe id="pokgak-citf" src="https://pokgak.github.io/citf-graphs/" style="border: none;" height="400" width="640" scrolling="no"></iframe>
+<iframe id="pokgak-citf" src="https://pokgak.github.io/citf-graphs/" title="Animasi kadar vaksinasi mengikut negeri di Malaysia" style="border: none;" height="400" width="640" scrolling="no"></iframe>
 {{< /rawhtml >}}
 
 ## Pembersihan Data
@@ -80,10 +81,8 @@ Dalam visualisasi graf bar, Plotly akan menunjukkan pertukaran posisi bar terseb
 
 Akhir sekali, parameter `labels` dan `title` digunakan untuk menetapkan label yang lebih mesra pembaca untuk legend, paksi, serta tajuk graf.
 
-# Konklusi
+## Konklusi
 
 Saya amat berpuas hati dengan animasi graf ini kerana saya telah belajar cara untuk menghasilkan jenis bentuk graf yang telah saya minati buat sekian lama. Namun begitu, walaupun graf ini kelihatan lebih cantik berbanding graf lain dengan animasi bergerak, saya akui apa yang telah saya hasilkan ini lebih kepada latihan menggunakan library Plotly itu sendiri. Masih banyak aspek yang boleh diperbaiki untuk menyampaikan maklumat menggunakan graf secara tepat dan efektif. 
 
 Untuk mengakses segala code yang telah saya tunjukkan di sini, boleh akses repository [pokgak/citf-graphs](https://github.com/pokgak/citf-graphs) di Github. Saya juga telah menetapkan jadual berkala supaya graf visualisasi tersebut dikemas kini setiap hari menggunakan Github Actions. Blog post cara saya bagaimana saya buat akan datang.
-
-

--- a/content/articles/hclwrite-basics.md
+++ b/content/articles/hclwrite-basics.md
@@ -1,6 +1,7 @@
 ---
 title: "Generate fail HCL menggunakan library hclwrite"
 date: 2021-09-19T12:25:34+08:00
+lang: ms
 ---
 
 HCL adalah bahasa yang digunakan dalam produk-produk daripada Hashicorp seperti Terraform dan Packer. Kebiasaannya, fail HCL ini ditulis secara manual tetapi jika anda ingin menulis atau mengubah fail-fail tersebut secara programmatik menggunakan code, maka anda boleh menggunakan [`hclwrite`](https://pkg.go.dev/github.com/hashicorp/hcl/v2@v2.10.1/hclwrite#Tokens), sebuah library yang ditulis dalam Go.

--- a/content/articles/instrument-your-ci.md
+++ b/content/articles/instrument-your-ci.md
@@ -77,7 +77,7 @@ otel-cli exec --service my-service --name "My First Trace" echo "HELLO WORLD"
 
 Then you should be able to see the a new line in the other terminal that we ran `otel-cli server tui` just now.
 
-![Result in otel-cli server](images/otel-cli-trace.png)
+![Terminal showing two otel-cli client spans named My First Trace and My Second Trace](images/otel-cli-trace.png)
 
 ## Conclusion
 

--- a/content/articles/k8s-cluster-access-tailscale.md
+++ b/content/articles/k8s-cluster-access-tailscale.md
@@ -6,7 +6,7 @@ images:
 - "images/k8s-external-dns-tailscale.png"
 ---
 
-![Full flow](images/k8s-external-dns-tailscale.png)
+![Six-step request flow connecting a Tailscale user to an internal Kubernetes Service through Cloudflare DNS, external-dns, and a Tailscale subnet router](images/k8s-external-dns-tailscale.png)
 
 I recently setup a local kubernetes in my home network to play with and one of the issues that I faced is that it is hard to access the services inside the cluster from my laptop. I don't have a load-balancer in my setup so everytime I want to access a service from my laptop, I'll have to run `kubectl port-forward` first before using the localhost address to access it. It works but it's annoying.
 

--- a/content/articles/otel-basics.md
+++ b/content/articles/otel-basics.md
@@ -137,7 +137,7 @@ TBH I'm still not clear what is the difference betwen using `NodeSDK` vs manuall
 
 To start manually instrumenting your application, you'll have to create a root span. A root span is the first span you create once the request enters your application. 
 
-![Request/Response Flow](images/request-flow.png)
+![Nested spans in a controller application: entryPoint contains calculateSomething and doSomething, while calculateSomething contains callApi](images/request-flow.png)
 
 Now, if you have a normal HTTP request/response-based application, it is easy to figure out where to start and end your root spans. All your incoming requests will most likely be handled by a controller and each endpoint will be handled by a method. In this type of application, your root span can be started once the request hits the application in the method in your controller and ends before you send the response.
 

--- a/content/articles/otel-slack-integration.md
+++ b/content/articles/otel-slack-integration.md
@@ -12,7 +12,7 @@ I've talked about the basics of OpenTelemetry in my previous article. In this on
 
 At the end of this article, this is roughly how the span lifetime and events created will look like:
 
-![Summary of spans and events created](images/slack-span-lifetime.png)
+![A user span begins at firstUserEvent, records nextEvent and nextEventB, then ends at finishingEvent](images/slack-span-lifetime.png)
 
 ## Slack BoltJS Socket Mode
 

--- a/content/articles/pengenalan-github-actions.md
+++ b/content/articles/pengenalan-github-actions.md
@@ -1,6 +1,7 @@
 ---
 title: "Pengenalan Github Actions"
 date: 2021-08-24T04:49:42+08:00
+lang: ms
 tags: [Github Actions, CI/CD]
 ---
 
@@ -11,15 +12,15 @@ Github Actions (GA) adalah servis automation yang ditawarkan oleh Github untuk s
 
 Untuk mula menggunakan Github Actions, anda boleh pergi ke mana-mana repository public yang anda miliki dan seterusnya pergi ke tab Actions.
 
-![](images/actions-tab.png)
+![Tab Actions dipilih dalam navigasi repositori GitHub](images/actions-tab.png)
 
 Jika anda belum pernah setup mana-mana workflow di repository tersebut, anda akan melihat pilihan templates siap yang boleh digunakan untuk pelbagai jenis projek. Sebagai pemula, saya cadangkan anda mula dengan template barebones yang ditawarkan.
 
-![](images/actions-get-started.png)
+![Halaman mula GitHub Actions yang mencadangkan workflow Jekyll](images/actions-get-started.png)
 
 Anda boleh menggunakan editor local di komputer sendiri tapi Github juga ada menawarkan editor online di mana fail workflow anda akan diperiksa formatnya secara langsung sambil anda menaip. Github akan highlight jika fail workflow anda mempunyai kesalahan yang membuatkan workflow anda akan gagal. Selain itu juga, di tepi editor online itu ada dipaparkan documentation ringkas mengenai syntax fail workflow jadi anda tidak perlu lagi tukar-tukar tab untuk semasa menulis fail workflow anda.
 
-![Github Actions online Editor](images/actions-editor.png)
+![Editor workflow GitHub Actions dengan fail YAML di sebelah dokumentasi Marketplace](images/actions-editor.png)
 
 ## Anatomi fail workflow Github Actions
 
@@ -119,4 +120,3 @@ Dalam contoh di atas, saya menggunakan Actions dari Github `actions/checkout` un
 Saya pernah menggunakan Jenkins dan Bitbucket Pipeline dan berdasarkan pengalaman saya Github Actions adalah jauh lebih baik dari kedua-dua produk CI/CD tersebut. Dokumentasi Github Actions yang ditawarkan Github adalah sangat lengkap. Saya paling banyak merujuk halaman [Workflow Syntax](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions) semasa mula belajar menggunakan Github Actions. Selain itu, halaman-halaman lain dalam [Reference](https://docs.github.com/en/actions/reference) ini juga sangat membantu anda ingin mula melakukan perkara yang lebih advance dengan Github Actions.
 
 Antara contoh automation yang pernah saya lakukan menggunakan Github Actions adalah, menjalankan unit test untuk setiap commit push, memeriksa dan baiki tajuk pull request secara automatik jika tidak memenuhi kriteria anda. Saya juga pernah menggunakan Github Actions workflow untuk melakukan DB dump daripada server dan terus upload ke S3. Pada pandangan saya, Github Actions sangat menarik dan macam-macam yang anda boleh lakukan dengannya.
-

--- a/content/articles/we-got-ddosed.md
+++ b/content/articles/we-got-ddosed.md
@@ -12,7 +12,7 @@ The first attack was around 10PM on a Sunday. I was at home at the time and was 
 
 Then, one of my colleagues showed me the metrics for new connections to our load balancer. We're getting 10x our usual traffic in a minute. That's a DDoS for sure.
 
-![New connections to load balancer](images/ddos-lb-active-flow.png)
+![Load balancer connection count with attack spikes reaching about 1.3 million connections](images/ddos-lb-active-flow.png)
 
 ## Rate limiting from the ingress-controller
 
@@ -70,7 +70,7 @@ We have NAT Gateways configured in our network which means that if the requests 
 
 After this incident, we created a [list on Cloudflare](https://developers.cloudflare.com/waf/tools/lists/) containing all our known IPs and skip blocking to avoid confusion in the future.
 
-![Slack message](images/slack-suspicious-ips.png)
+![Slack message identifying two suspicious IP addresses with repeated unauthenticated requests](images/slack-suspicious-ips.png)
 
 ### Blocking accessibility bots (from US)
 


### PR DESCRIPTION
## What changed

- add a keyboard-operable skip link, named primary navigation, active-page state, and one useful homepage `h1`
- add visible focus indicators in light and dark themes, including focusable horizontally scrollable code blocks
- expose accurate dark-mode button labels and pressed state while hiding decorative SVGs
- support per-page `lang` metadata and mark the seven audited Malay articles as `ms`
- add meaningful titles to talk and article iframes and remove obsolete talk embed attributes
- audit rendered images and replace empty or vague alternative text with descriptions based on the actual assets and article context
- make duplicate talk thumbnails decorative
- make the header wrap cleanly on small screens

## Why

Shared templates and older content were missing landmarks, language metadata, keyboard focus behavior, control state, iframe titles, and useful image alternatives. These gaps made the site harder to navigate and understand with keyboards and assistive technology.

## Validation

- `npm run build`
- `git diff --check`
- generated-page audit: exactly one `h1` per HTML page, no rendered image without `alt`, no iframe without `title`
- axe-core 4.12.1 WCAG 2 A/AA and WCAG 2.1 A/AA on:
  - homepage
  - article index
  - English article
  - Malay article
  - talk page
- zero axe violations on all representative pages
- keyboard-tested skip navigation, logical tab order, light/dark focus indicators, and dark-mode label/`aria-pressed` changes
- visually reviewed the homepage at a 390 × 844 mobile viewport
