### PR TITLE
Fix high-severity js-yaml vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -516,9 +516,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",


### PR DESCRIPTION
## Summary
- update transitive `js-yaml` from 3.14.2 to 3.15.0 in the lockfile
- resolve GHSA-h67p-54hq-rp68 and GHSA-52cp-r559-cp3m
- retain `gray-matter@4.0.3`; its existing `js-yaml@^3.13.1` range accepts the patched release

## Validation
- `npm ci`
- `npm run build`
- `node --check build.js`
- `node --check tailwind.config.js`
- validated frontmatter for all 57 content files
- generated HTML/RSS/CSS smoke checks
- `npm audit`: 0 vulnerabilities
- `npm audit --omit=dev`: 0 vulnerabilities