### PR TITLE
Add repeatable orb browser testing

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Installing locked Node.js dependencies..."
+npm ci
+
+echo "Ensuring the agent-browser Chrome binary is installed..."
+command -v agent-browser >/dev/null
+agent-browser install
+
+echo "Building the site..."
+npm run build

--- a/.amp/services.yaml
+++ b/.amp/services.yaml
@@ -1,0 +1,6 @@
+services:
+  blog:
+    command: npm run build && npm run preview -- "$PORT"
+    portal:
+      title: Blog Preview
+      description: Generated blog preview for browser testing.

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 public/
+.amp/portals/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,29 @@ make preview   # build + serve locally
 make clean     # rm -rf public
 ```
 
+## Orb Browser Testing
+
+Fresh Amp orbs run `.agents/setup`, which installs locked npm dependencies,
+installs the Chrome binary used by the orb-provided `agent-browser`, and builds
+the site. The supervised preview service is declared in `.amp/services.yaml`.
+
+Start or reconcile the service and print its portal URL:
+
+```bash
+amp orb services ensure
+```
+
+Run the smoke test against that portal URL:
+
+```bash
+npm run test:browser -- https://<portal-url>
+```
+
+For a local preview listening on port 3000, run `npm run build && npm run
+preview -- 3000`, then run `npm run test:browser`. The test uses an
+isolated `agent-browser` session to verify the homepage, theme toggle, primary
+navigation, an article page, and the generated agent-discovery files.
+
 ## Content Types
 
 There are three content types:

--- a/package-lock.json
+++ b/package-lock.json
@@ -516,9 +516,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "build": "node build.js && tailwindcss -i static/styles.css -o public/styles.css --minify",
-    "preview": "npx serve public"
+    "preview": "node scripts/serve.js",
+    "test:browser": "bash scripts/smoke-browser.sh"
   },
   "dependencies": {
     "gray-matter": "^4.0.3",

--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -1,0 +1,76 @@
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+
+const publicDir = path.resolve(__dirname, '..', 'public');
+const port = Number(process.argv[2] || process.env.PORT || 3000);
+const mimeTypes = {
+  '.css': 'text/css; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.jpg': 'image/jpeg',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.md': 'text/markdown; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.txt': 'text/plain; charset=utf-8',
+  '.webp': 'image/webp',
+  '.xml': 'application/xml; charset=utf-8',
+};
+
+if (!Number.isInteger(port) || port < 1 || port > 65535) {
+  console.error(`Invalid port: ${process.argv[2] || process.env.PORT}`);
+  process.exit(1);
+}
+
+function send(response, status, body) {
+  response.writeHead(status, { 'content-type': 'text/plain; charset=utf-8' });
+  response.end(body);
+}
+
+const server = http.createServer((request, response) => {
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    send(response, 405, 'Method not allowed\n');
+    return;
+  }
+
+  let pathname;
+  try {
+    pathname = decodeURIComponent(new URL(request.url, 'http://localhost').pathname);
+  } catch {
+    send(response, 400, 'Bad request\n');
+    return;
+  }
+
+  let filePath = path.resolve(publicDir, `.${pathname}`);
+  if (filePath !== publicDir && !filePath.startsWith(`${publicDir}${path.sep}`)) {
+    send(response, 403, 'Forbidden\n');
+    return;
+  }
+
+  fs.stat(filePath, (statError, stats) => {
+    if (!statError && stats.isDirectory()) filePath = path.join(filePath, 'index.html');
+
+    fs.stat(filePath, (fileError, fileStats) => {
+      if (fileError || !fileStats.isFile()) {
+        send(response, 404, 'Not found\n');
+        return;
+      }
+
+      response.writeHead(200, {
+        'content-length': fileStats.size,
+        'content-type': mimeTypes[path.extname(filePath).toLowerCase()] || 'application/octet-stream',
+      });
+      if (request.method === 'HEAD') response.end();
+      else fs.createReadStream(filePath).pipe(response);
+    });
+  });
+});
+
+server.listen(port, '0.0.0.0', () => {
+  console.log(`Serving ${publicDir} on port ${port}`);
+});
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => server.close(() => process.exit(0)));
+}

--- a/scripts/smoke-browser.sh
+++ b/scripts/smoke-browser.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#   npm run test:browser
+#   npm run test:browser -- https://<portal-url>
+#   BASE_URL=https://<portal-url> npm run test:browser
+BASE_URL="${1:-${BASE_URL:-http://127.0.0.1:3000}}"
+BASE_URL="${BASE_URL%/}"
+SESSION="pokgak-smoke-$$"
+
+command -v agent-browser >/dev/null
+command -v curl >/dev/null
+
+browser() {
+  agent-browser --session "$SESSION" "$@"
+}
+
+cleanup() {
+  browser close >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+assert_equal() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'FAIL: %s\n  expected: %s\n  actual:   %s\n' "$label" "$expected" "$actual" >&2
+    exit 1
+  fi
+  printf 'PASS: %s\n' "$label"
+}
+
+assert_contains() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [[ "$actual" != *"$expected"* ]]; then
+    printf 'FAIL: %s\n  expected to contain: %s\n  actual:              %s\n' "$label" "$expected" "$actual" >&2
+    exit 1
+  fi
+  printf 'PASS: %s\n' "$label"
+}
+
+echo "Running browser smoke tests against $BASE_URL"
+browser open "$BASE_URL"
+browser wait --load domcontentloaded
+browser snapshot -i >/dev/null
+assert_equal "Aiman Ismail" "$(browser get title)" "home page title"
+assert_equal "Latest Writing" "$(browser get text 'main h1')" "home page heading"
+
+pressed_before="$(browser get attr '#theme-toggle' aria-pressed)"
+browser click '#theme-toggle'
+pressed_after="$(browser get attr '#theme-toggle' aria-pressed)"
+if [[ "$pressed_before" == "$pressed_after" ]]; then
+  echo "FAIL: theme toggle did not update aria-pressed" >&2
+  exit 1
+fi
+echo "PASS: theme toggle updates its accessible state"
+
+browser click 'header a[href="/articles/"]'
+browser wait --url '**/articles/'
+assert_equal "Articles" "$(browser get text 'main h1')" "Articles navigation"
+
+browser click 'main li:first-child a'
+browser wait --load domcontentloaded
+assert_contains "/articles/" "$(browser get url)" "article detail navigation"
+article_title="$(browser get text 'main article h1')"
+[[ -n "$article_title" ]] || { echo "FAIL: article detail heading is empty" >&2; exit 1; }
+echo "PASS: article detail renders a heading"
+
+for section in notes experiments talks; do
+  browser click "header a[href=\"/$section/\"]"
+  browser wait --url "**/$section/"
+  heading="$(browser get text 'main h1')"
+  expected="${section^}"
+  assert_equal "$expected" "$heading" "$expected navigation"
+done
+
+browser click 'header > a[href="/"]'
+browser wait --url "$BASE_URL/"
+assert_equal "Latest Writing" "$(browser get text 'main h1')" "home navigation"
+
+llms_txt="$(curl -fsS "$BASE_URL/llms.txt")"
+grep -q '^# Aiman Ismail$' <<<"$llms_txt"
+echo "PASS: llms.txt is served"
+sitemap_xml="$(curl -fsS "$BASE_URL/sitemap.xml")"
+grep -q '<urlset ' <<<"$sitemap_xml"
+echo "PASS: sitemap.xml is served"
+robots_txt="$(curl -fsS "$BASE_URL/robots.txt")"
+grep -q '^Sitemap: https://pokgak.xyz/sitemap.xml$' <<<"$robots_txt"
+echo "PASS: robots.txt is served"
+
+echo "Browser smoke tests passed."


### PR DESCRIPTION
## Summary

- add an executable `.agents/setup` that installs locked npm dependencies, ensures the orb-provided `agent-browser` has Chrome installed, and builds the site
- declare a supervised, portaled blog preview in `.amp/services.yaml`
- add a dependency-free Node preview server and an isolated `agent-browser` smoke test covering navigation, theme accessibility state, an article page, and agent-discovery files
- document exact orb and local browser-testing commands
- patch transitive `js-yaml` from 3.14.2 to 3.15.0 within `gray-matter`'s existing range, clearing the high-severity audit finding

## Validation

- `.agents/setup` passed repeatedly and detected the existing Chrome 151 installation on the second run
- `amp orb services ensure` and `amp orb service restart blog` reported a healthy HTTP 200 service
- `npm run test:browser -- <portal-url>` passed all homepage, theme toggle, Articles/article detail, Notes, Experiments, Talks, home-return, `llms.txt`, sitemap, and robots assertions
- `node --check scripts/serve.js`
- `bash -n .agents/setup scripts/smoke-browser.sh`
- executable-bit checks for `.agents/setup` and `scripts/smoke-browser.sh`
- `npm ci`, `npm audit`, and `npm ls js-yaml` confirmed 0 vulnerabilities and `gray-matter@4.0.3 -> js-yaml@3.15.0`
- `npm run build`
- `git diff --check`
